### PR TITLE
Fix build error due to `use serde::export::fmt::Display`

### DIFF
--- a/src/error.rs
+++ b/src/error.rs
@@ -1,6 +1,5 @@
-use serde::export::fmt::Display;
 use std::error::Error;
-use std::fmt::Formatter;
+use std::fmt::{Display, Formatter};
 
 #[derive(Debug, Clone)]
 pub struct HttpError {


### PR DESCRIPTION
Remove import of `serde::export::fmt::Display` in favor of `std::fmt::Display`